### PR TITLE
Fix speaker notes not being written in slides_update_slide

### DIFF
--- a/google_slides_mcp.py
+++ b/google_slides_mcp.py
@@ -107,6 +107,20 @@ def find_placeholder(elements, p_type):
             return el.get('objectId')
     return None
 
+def find_speaker_notes_object_id(slide: Dict[str, Any]) -> Optional[str]:
+    """Returns the speaker notes shape objectId for a slide."""
+    notes_page = slide.get('notesPage') or {}
+    notes_properties = notes_page.get('notesProperties') or {}
+    if notes_properties.get('speakerNotesObjectId'):
+        return notes_properties['speakerNotesObjectId']
+
+    # Fallback for older/partial payloads where notesProperties is absent.
+    for placeholder_type in ('SPEAKER_NOTES', 'BODY'):
+        placeholder_id = find_placeholder(notes_page.get('pageElements', []), placeholder_type)
+        if placeholder_id:
+            return placeholder_id
+    return None
+
 # --- Tools ---
 
 @mcp.tool(name="slides_create_presentation")
@@ -208,15 +222,18 @@ async def update_slide(params: UpdateSlideInput) -> str:
             requests.append({'insertText': {'objectId': body_id, 'text': params.body}})
 
         # 3. Handle Speaker Notes
-        if params.speaker_notes:
-            notes_page = slide.get('notesPage')
-            if notes_page:
-                notes_element = find_placeholder(notes_page.get('pageElements', []), 'BODY')
-                notes_obj_id = notes_element.get('objectId') if notes_element else None
-                if notes_obj_id:
-                    if has_text_content(notes_element):
-                        requests.append({'deleteText': {'objectId': notes_obj_id, 'textRange': {'type': 'ALL'}}})
-                    requests.append({'insertText': {'objectId': notes_obj_id, 'text': params.speaker_notes}})
+        if params.speaker_notes is not None:
+            notes_obj_id = find_speaker_notes_object_id(slide)
+            if notes_obj_id:
+                requests.append({'deleteText': {'objectId': notes_obj_id, 'textRange': {'type': 'ALL'}}})
+                if params.speaker_notes:
+                    requests.append({
+                        'insertText': {
+                            'objectId': notes_obj_id,
+                            'insertionIndex': 0,
+                            'text': params.speaker_notes
+                        }
+                    })
 
         if not requests:
             return "No updates performed. Check if placeholders exist on the slide."

--- a/tests/test_placeholders.py
+++ b/tests/test_placeholders.py
@@ -5,7 +5,7 @@ import os
 # Add the parent directory to the path so we can import the module
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from google_slides_mcp import find_placeholder
+from google_slides_mcp import find_placeholder, find_speaker_notes_object_id
 
 class TestFindPlaceholder(unittest.TestCase):
 
@@ -62,6 +62,46 @@ class TestFindPlaceholder(unittest.TestCase):
     def test_handles_empty_elements(self):
         result = find_placeholder([], 'TITLE')
         self.assertIsNone(result)
+
+class TestFindSpeakerNotesObjectId(unittest.TestCase):
+    def test_prefers_notes_properties_id(self):
+        slide = {
+            "notesPage": {
+                "notesProperties": {"speakerNotesObjectId": "notes-shape-1"},
+                "pageElements": []
+            }
+        }
+        self.assertEqual(find_speaker_notes_object_id(slide), "notes-shape-1")
+
+    def test_falls_back_to_speaker_notes_placeholder(self):
+        slide = {
+            "notesPage": {
+                "pageElements": [
+                    {
+                        "objectId": "speaker-notes-shape",
+                        "shape": {"placeholder": {"type": "SPEAKER_NOTES"}}
+                    }
+                ]
+            }
+        }
+        self.assertEqual(find_speaker_notes_object_id(slide), "speaker-notes-shape")
+
+    def test_falls_back_to_body_placeholder(self):
+        slide = {
+            "notesPage": {
+                "pageElements": [
+                    {
+                        "objectId": "notes-body-shape",
+                        "shape": {"placeholder": {"type": "BODY"}}
+                    }
+                ]
+            }
+        }
+        self.assertEqual(find_speaker_notes_object_id(slide), "notes-body-shape")
+
+    def test_returns_none_without_notes_shape(self):
+        slide = {"notesPage": {"pageElements": []}}
+        self.assertIsNone(find_speaker_notes_object_id(slide))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix `slides_update_slide` to resolve speaker notes via `notesPage.notesProperties.speakerNotesObjectId` (primary path used by Google Slides API)
- keep fallback support for placeholder-based detection (`SPEAKER_NOTES` then `BODY`) for partial/older payloads
- allow explicit speaker-notes clearing when `speaker_notes` is provided as an empty string
- add `insertionIndex: 0` when inserting speaker notes text
- add unit tests for speaker-notes object id resolution

## Root cause
The previous implementation attempted to find notes text only through a `BODY` placeholder on the notes page. In many real responses, notes are identified by `notesProperties.speakerNotesObjectId`, so the update request skipped notes and nothing appeared in the final deck.

## Verification
- `python3 -m unittest discover tests` passed (7 tests).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bad2cce1-7f3a-4b3f-afc3-521261bb7c36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bad2cce1-7f3a-4b3f-afc3-521261bb7c36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

